### PR TITLE
MAGIC AND MOONDUST

### DIFF
--- a/code/__DEFINES/magic/spells.dm
+++ b/code/__DEFINES/magic/spells.dm
@@ -1,7 +1,6 @@
 #define SPELL_FIREBALL_old							/obj/effect/proc_holder/spell/aimed/fireball
 #define SPELL_BLINDNESS_AOE							/obj/effect/proc_holder/spell/aoe_turf/blindness
 #define SPELL_KNOCK									/obj/effect/proc_holder/spell/aoe_turf/knock
-#define SPELL_REPULSE								/obj/effect/proc_holder/spell/aoe_turf/repulse	//This is the one we use.
 #define SPELL_REPULSE_XENO							/obj/effect/proc_holder/spell/aoe_turf/repulse/xeno
 #define SPELL_TIMESTOP								/obj/effect/proc_holder/spell/aoe_turf/timestop
 #define SPELL_BLOODCRAWL							/obj/effect/proc_holder/spell/bloodcrawl
@@ -138,4 +137,3 @@
 #define SPELL_ARCYNE_STORM							/obj/effect/proc_holder/spell/invoked/arcyne_storm
 #define SPELL_SUMMON_WEAPON							/obj/effect/proc_holder/spell/targeted/summonweapon
 #define SPELL_MENDING								/obj/effect/proc_holder/spell/invoked/mending
-#define SPELL_REPEL									/obj/effect/proc_holder/spell/invoked/projectile/repel

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -114,7 +114,10 @@
 	id = "moondust"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/druqks
 	effectedstats = list("speed" = 4, "endurance" = 4, "perception" = -3)
-	duration = 30 SECONDS
+	duration = 40 SECONDS
+
+/datum/status_effect/buff/moondust/nextmove_modifier()
+	return 0.15
 
 /datum/status_effect/buff/moondust/on_apply()
 	. = ..()
@@ -129,7 +132,10 @@
 	id = "purest moondust"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/druqks
 	effectedstats = list("speed" = 5, "endurance" = 5, "perception" = -2)
-	duration = 40 SECONDS
+	duration = 60 SECONDS
+
+/datum/status_effect/buff/moondust_purest/nextmove_modifier()
+	return 0.20
 
 /datum/status_effect/buff/moondust_purest/on_apply()
 	. = ..()

--- a/code/game/turfs/closed/wall/roguewalls.dm
+++ b/code/game/turfs/closed/wall/roguewalls.dm
@@ -150,7 +150,7 @@
 	above_floor = /turf/open/floor/rogue/twig
 	baseturfs = list(/turf/open/floor/rogue/twig)
 	neighborlay = "dirtedge"
-	climbdiff = 99 //how are you even supposed to climb a tent??
+	climbdiff = 3 //how are you even supposed to climb a tent??
 	explosion_block = 0
 	hardness = 70
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -166,7 +166,7 @@
 	damage = 15
 	damage_type = BURN
 	flag = "magic"
-	dismemberment = 50
+	dismemberment = 0
 	nodamage = FALSE
 
 /obj/projectile/magic/spellblade/on_hit(target)

--- a/code/modules/spells/roguetown/wizard.dm
+++ b/code/modules/spells/roguetown/wizard.dm
@@ -38,8 +38,8 @@ Unless of course, they went heavy into the gameplay loop, and got a better book.
 		SPELL_ARCANEBOLT,			// 3 cost	combat, single target single shot damage
 	//	SPELL_FROSTBOLT,			// 3 cost	combat, single target, single shot lesser damage w/ slow
 	//	SPELL_LIGHTNINGLURE,		// 3 cost	combat, ranged single target hard stun w/ time requirement.
-		SPELL_SLOWDOWN_SPELL_AOE,	// 3 cost	utility hold spell. Target unable to move, but can fight.
-		SPELL_FINDFAMILIAR,			// 3 cost	combat, summon spell.
+	//	SPELL_SLOWDOWN_SPELL_AOE,	// 3 cost	utility hold spell. Target unable to move, but can fight.
+	//	SPELL_FINDFAMILIAR,			// 3 cost	combat, summon spell.
 		//SPELL_PUSH_SPELL,			// 3 cost	localized AOE knockback spell. Knocksdown/disarms victims
 		//SPELL_ARCYNE_STORM,			// 2 cost	combat, light damaging AOE, stall/area denial spell
 		SPELL_DARKVISION,			// 2 cost	utility, dark sight
@@ -48,7 +48,7 @@ Unless of course, they went heavy into the gameplay loop, and got a better book.
 		SPELL_MENDING,				// 2 cost	utility, repairs items
 		SPELL_MESSAGE,				// 2 cost	utility, messages anyone you know the name of.
 		SPELL_BLADE_BURST,			// 2 cost	combat, single target damage localized on rndm leg. possible bone break.
-	//	SPELL_FETCH,				// 2 cost	utility/combat, pulls single target closer
+		SPELL_FETCH,				// 2 cost	utility/combat, pulls single target closer
 		SPELL_FORCEWALL_WEAK,		// 2 cost	utility/combat, places walls caster can walk through. stall spell.
 		SPELL_NONDETECTION,			// 1 cost	utility, no scrying your location.
 		SPELL_FEATHERFALL,			// 1 cost	utility, no fall damage from 1 zlevel drop
@@ -222,7 +222,7 @@ Unless of course, they went heavy into the gameplay loop, and got a better book.
 			return BULLET_ACT_BLOCK
 		if(isliving(target))
 			var/mob/living/L = target
-			L.electrocute_act(1, src)
+			L.electrocute_act(0, src)
 	qdel(src)
 
 /obj/effect/proc_holder/spell/invoked/projectile/bloodsteal
@@ -365,13 +365,13 @@ Unless of course, they went heavy into the gameplay loop, and got a better book.
 	exp_fire = 4
 	exp_hotspot = 0
 	flag = "magic"
-	speed = 6
+	speed = 3
 
 /obj/effect/proc_holder/spell/invoked/projectile/spitfire
 	name = "Spitfire"
 	desc = "Shoot out a series of low-powered balls of fire that shines brightly on impact, potentially blinding a target."
 	clothes_req = FALSE
-	range = 8
+	range = 6
 	projectile_type = /obj/projectile/magic/aoe/rogue2
 	overlay_state = "fireball_multi"
 	sound = list('sound/magic/whiteflame.ogg')
@@ -479,7 +479,7 @@ Unless of course, they went heavy into the gameplay loop, and got a better book.
 	name = "Fetch"
 	desc = "Shoot out a magical bolt that draws in the target struck towards the caster."
 	clothes_req = FALSE
-	range = 15
+	range = 3
 	projectile_type = /obj/projectile/magic/fetch
 	overlay_state = ""
 	sound = list('sound/magic/magnet.ogg')

--- a/code/modules/spells/roguetown/wizard.dm
+++ b/code/modules/spells/roguetown/wizard.dm
@@ -30,26 +30,25 @@ Unless of course, they went heavy into the gameplay loop, and got a better book.
 
 	var/list/spell_choices = list(
 		SPELL_FIREBALLGREATER,		// 13 cost	combat, AOE heavy single target damage
-		SPELL_METEOR,				// 13 cost	combat, LARGE AOE, light damage.
-		SPELL_SUNDER_LIGHTNING,		// 13 cost	combat, upper level AOE hard stunning damage
+	//	SPELL_METEOR,				// 13 cost	combat, LARGE AOE, light damage.
+	//	SPELL_SUNDER_LIGHTNING,		// 13 cost	combat, upper level AOE hard stunning damage
 		SPELL_FIREBALL,				// 3 cost	combat, damaging AOE + damages worn/held things
-		SPELL_LIGHTNINGBOLT,		// 3 cost	combat, single target damage, knockdown
+	//	SPELL_LIGHTNINGBOLT,		// 3 cost	combat, single target damage, knockdown
 		SPELL_SPITFIRE,				// 3 cost	combat, burstfire single target damage
 		SPELL_ARCANEBOLT,			// 3 cost	combat, single target single shot damage
-		SPELL_FROSTBOLT,			// 3 cost	combat, single target, single shot lesser damage w/ slow
-		SPELL_LIGHTNINGLURE,		// 3 cost	combat, ranged single target hard stun w/ time requirement.
+	//	SPELL_FROSTBOLT,			// 3 cost	combat, single target, single shot lesser damage w/ slow
+	//	SPELL_LIGHTNINGLURE,		// 3 cost	combat, ranged single target hard stun w/ time requirement.
 		SPELL_SLOWDOWN_SPELL_AOE,	// 3 cost	utility hold spell. Target unable to move, but can fight.
 		SPELL_FINDFAMILIAR,			// 3 cost	combat, summon spell.
-		SPELL_PUSH_SPELL,			// 3 cost	localized AOE knockback spell. Knocksdown/disarms victims
-		SPELL_ARCYNE_STORM,			// 2 cost	combat, light damaging AOE, stall/area denial spell
+		//SPELL_PUSH_SPELL,			// 3 cost	localized AOE knockback spell. Knocksdown/disarms victims
+		//SPELL_ARCYNE_STORM,			// 2 cost	combat, light damaging AOE, stall/area denial spell
 		SPELL_DARKVISION,			// 2 cost	utility, dark sight
 		SPELL_HASTE,				// 2 cost	utility/combatbuff, faster mve speed.
 		SPELL_SUMMON_WEAPON,		// 2 cost	utility/combat, summons a marked weapon to caster.
 		SPELL_MENDING,				// 2 cost	utility, repairs items
 		SPELL_MESSAGE,				// 2 cost	utility, messages anyone you know the name of.
 		SPELL_BLADE_BURST,			// 2 cost	combat, single target damage localized on rndm leg. possible bone break.
-		SPELL_FETCH,				// 2 cost	utility/combat, pulls single target closer
-		SPELL_REPEL,				// 2 cost	utility/combat, flings single target away
+	//	SPELL_FETCH,				// 2 cost	utility/combat, pulls single target closer
 		SPELL_FORCEWALL_WEAK,		// 2 cost	utility/combat, places walls caster can walk through. stall spell.
 		SPELL_NONDETECTION,			// 1 cost	utility, no scrying your location.
 		SPELL_FEATHERFALL,			// 1 cost	utility, no fall damage from 1 zlevel drop
@@ -1481,7 +1480,7 @@ Unless of course, they went heavy into the gameplay loop, and got a better book.
 /obj/effect/proc_holder/spell/invoked/meteor_storm
 	name = "Meteor storm"
 	desc = "Summons forth dangerous meteors from the sky to scatter and smash foes."
-	cost = 13
+	cost = 1300
 	releasedrain = 50
 	chargedrain = 1
 	chargetime = 50
@@ -1661,7 +1660,7 @@ obj/effect/proc_holder/spell/targeted/summonweapon/cast(list/targets,mob/user = 
 /obj/effect/proc_holder/spell/invoked/sundering_lightning
 	name = "Sundering Lightning"
 	desc = "Summons forth dangerous rapid lightning strikes."
-	cost = 13
+	cost = 1300
 	releasedrain = 50
 	chargedrain = 1
 	chargetime = 50

--- a/code/modules/spells/spell_types/lightning.dm
+++ b/code/modules/spells/spell_types/lightning.dm
@@ -6,7 +6,7 @@
 	clothes_req = TRUE
 	invocation = "UN'LTD P'WAH!"
 	invocation_type = "shout"
-	range = 7
+	range = 0
 	cooldown_min = 30
 	selection_type = "view"
 	random_target = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

-- REPULSE has been removed, it's an AOE knockdown disarm attack with no counter.
-- REPEL has been removed, ditto.
-- BLADEBURST no longer can break limbs, it having a 50/50 chance to instantly cripple someone was stupid.
-- METEOR has been removed, it's an AOE attack capable of wiping out entire camps of people, what the fuck.
-- SUNDER_LIGHTNING has been removed, it was lightning bolt but AOE and capable of stomping entire camps of people, what the fuck
-- FROSTBOLT has been removed, it's a very fucking hard to counter spell that would slow you down a shit load, why?
-- LIGHTNINGBOLT has been removed, a hitscan spell capable of stunlocking someone while disarming and dropping them to the floor was beyond busted.
-- SUMMON FAMILIAR has been removed, with the current state of mobs this spell was completely and utterly DISGUSTING and had no reasonable counter; I've seen many fights where someone behind a gate could just spam volfs at someone, not fun!
-- FETCH remains, but now is only a few tiles (subject to change), this is because the ability to drag someone 15 tiles into a dogpile was pretty busted and overall unfun.


## MOONDUST AND TENT WALLS ##
- Moondust is BACK, by this I mean it's attack speed increase is back in the game and duration slightly increased from 30 seconds all the way up to 40 (at least for regular).
- UNCUT Moondust is the shit again, even faster attacks then moondust AND lasts 60 seconds.
- Once more, tent walls can be climbed. Yay.



## Why It's Good For The Game

Balance is good and one shot spells are dogshit.


## Proof of Testing (Required)

Shit don't crash on startup, so we're good.
