### PR TITLE
(TastyFish)-Crafting-Causing-Bundle-to-Disappear-on-Last

### DIFF
--- a/code/__HELPERS/crafting.dm
+++ b/code/__HELPERS/crafting.dm
@@ -393,8 +393,12 @@ proc/del_reqs(datum/crafting_recipe/R, mob/user)
 								B.update_bundle()
 								switch(B.amount)
 									if(1)
-										new B.stacktype(B.loc)
+										var/mob/living/carbon/old_loc = B.loc
 										qdel(B)
+										var/new_item = new B.stacktype(old_loc)
+										// Put in the person's hands if there were holding it.
+										if(ishuman(old_loc))
+											old_loc.put_in_hands(new_item)
 									if(0)
 										qdel(B)
 								amt = 0


### PR DESCRIPTION
## About The Pull Request

Fixes the issue with crafting causing bundles of items to disappear when you reach 1.

Made by Tastyfish, pulled from RATWOOD.