### PR TITLE
Manor's security balance. (Additional changes to the Marshal/councilor's rooms.

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -2263,10 +2263,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"cCw" = (
-/obj/effect/landmark/start/councillor,
-/turf/open/floor/rogue/tile/masonic/single,
-/area/rogue/indoors/town/manor)
 "cCQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood,
@@ -2365,6 +2361,12 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
+"cIT" = (
+/obj/structure/bed/rogue/inn,
+/obj/item/bedsheet/rogue/fabric,
+/obj/effect/landmark/start/councillor,
+/turf/open/floor/rogue/tile/masonic/single,
+/area/rogue/indoors/town/manor)
 "cJt" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -5119,11 +5121,8 @@
 	},
 /area/rogue/indoors/town/magician)
 "fHm" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/pelt,
-/obj/effect/landmark/start/councillor,
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/manor)
+/turf/closed/wall/mineral/rogue/decowood,
+/area/rogue/outdoors/town)
 "fHo" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -11160,14 +11159,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
-"mxR" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 1;
-	locked = 1;
-	lockid = Manor
-	},
-/turf/open/floor/rogue/tile/masonic/inverted,
-/area/rogue/indoors/town/manor)
 "myl" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -11295,9 +11286,12 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
 "mJn" = (
-/obj/structure/bed/rogue/inn,
-/obj/item/bedsheet/rogue/fabric,
-/turf/open/floor/rogue/tile/masonic/single,
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = Manor
+	},
+/turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "mJz" = (
 /obj/structure/closet/crate/chest{
@@ -12274,9 +12268,6 @@
 /area/rogue/indoors/town/church)
 "nPt" = (
 /obj/machinery/light/rogue/wallfire/candle,
-/obj/structure/closet/crate/drawer,
-/obj/item/candle/yellow,
-/obj/item/natural/feather,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "nPR" = (
@@ -17193,7 +17184,6 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin)
 "tkS" = (
-/obj/structure/closet/crate/roguecloset/dark,
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
@@ -17210,6 +17200,11 @@
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
+/obj/structure/closet/crate/roguecloset/dark{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/natural/feather,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "tlB" = (
@@ -17630,12 +17625,6 @@
 /obj/structure/fluff/canopy/side,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"tKf" = (
-/obj/structure/mineral_door/bars{
-	lockid = "manor"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town/roofs)
 "tKg" = (
 /obj/structure/bars/grille,
 /turf/open/transparent/openspace,
@@ -17845,9 +17834,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "tVZ" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/wool,
 /obj/effect/landmark/start/councillor,
+/obj/structure/bed/rogue/inn,
+/obj/item/bedsheet/rogue/fabric,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "tWz" = (
@@ -18498,6 +18487,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church)
+"uEm" = (
+/obj/structure/closet/crate/chest/crafted,
+/turf/open/floor/rogue/tile/masonic/inverted,
+/area/rogue/indoors/town/manor)
 "uEx" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -19469,6 +19462,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
+"vKv" = (
+/obj/structure/mineral_door/bars{
+	lockid = "manor"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/roofs)
 "vKy" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -384646,7 +384645,7 @@ rTC
 rTC
 rTC
 rTC
-tKf
+vKv
 rTC
 rTC
 rTC
@@ -487962,7 +487961,7 @@ tgZ
 los
 bFU
 rdP
-mxR
+mJn
 tPh
 tPh
 nkW
@@ -489976,13 +489975,13 @@ naI
 tVZ
 rdP
 rdP
+uEm
 naI
 bxD
 tgZ
 tgZ
-mJn
-naI
-tWQ
+cIT
+fHm
 tWQ
 tWQ
 tWQ
@@ -490378,13 +490377,13 @@ naI
 nPt
 rdP
 rdP
+rdP
 naI
 tgZ
 tgZ
 tgZ
 tgZ
-naI
-tWQ
+fHm
 tWQ
 tWQ
 tWQ
@@ -490777,16 +490776,16 @@ bFU
 tgZ
 wtF
 naI
-fHm
 rdP
 rdP
+rdP
+tkS
 naI
 tkS
-tgZ
 vKN
-cCw
-naI
-tWQ
+tgZ
+tgZ
+fHm
 tWQ
 tWQ
 tWQ
@@ -491188,7 +491187,7 @@ ogw
 naI
 naI
 naI
-tWQ
+fHm
 tWQ
 tWQ
 tWQ
@@ -501649,8 +501648,8 @@ tWQ
 tWQ
 qSA
 esF
-xAt
-xAt
+hGn
+oml
 xAt
 xAt
 xAt
@@ -502051,8 +502050,8 @@ tWQ
 tWQ
 qSA
 esF
-xAt
-xAt
+hSp
+uKX
 xAt
 xAt
 fkC
@@ -502453,8 +502452,8 @@ tWQ
 tWQ
 qSA
 esF
-xAt
-xAt
+hSp
+esF
 xAt
 fkC
 fkC
@@ -502855,8 +502854,8 @@ tWQ
 tWQ
 qSA
 esF
-xAt
-xAt
+hGn
+eUb
 xAt
 fkC
 wyk

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -2263,6 +2263,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
+"cCw" = (
+/obj/effect/landmark/start/councillor,
+/turf/open/floor/rogue/tile/masonic/single,
+/area/rogue/indoors/town/manor)
 "cCQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood,
@@ -5216,7 +5220,7 @@
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
-/turf/open/floor/rogue/ruinedwood,
+/turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/town)
 "fNc" = (
 /obj/structure/flora/roguegrass/bush,
@@ -5477,7 +5481,7 @@
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
 	locked = 1;
-	lockid = "keep_dungeon"
+	lockid = Manor
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
@@ -11156,6 +11160,14 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/bog)
+"mxR" = (
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = Manor
+	},
+/turf/open/floor/rogue/tile/masonic/inverted,
+/area/rogue/indoors/town/manor)
 "myl" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -11285,7 +11297,6 @@
 "mJn" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/fabric,
-/obj/effect/landmark/start/marshal,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "mJz" = (
@@ -17619,6 +17630,12 @@
 /obj/structure/fluff/canopy/side,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"tKf" = (
+/obj/structure/mineral_door/bars{
+	lockid = "manor"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/roofs)
 "tKg" = (
 /obj/structure/bars/grille,
 /turf/open/transparent/openspace,
@@ -384629,7 +384646,7 @@ rTC
 rTC
 rTC
 rTC
-rTC
+tKf
 rTC
 rTC
 rTC
@@ -385031,7 +385048,7 @@ vIa
 wtF
 wtF
 wtF
-wtF
+yhZ
 wtF
 wtF
 rTC
@@ -385431,10 +385448,10 @@ vIa
 vIa
 vIa
 wtF
-hLW
-hLW
-hLW
-hLW
+yhZ
+yhZ
+yhZ
+yhZ
 wtF
 wtF
 eMc
@@ -385833,11 +385850,11 @@ vIa
 vIa
 vIa
 wtF
-hLW
-hLW
-hLW
-hLW
-hLW
+yhZ
+yhZ
+yhZ
+yhZ
+yhZ
 wtF
 rTC
 rTC
@@ -386235,11 +386252,11 @@ vIa
 vIa
 vIa
 wtF
-hLW
-hLW
-hLW
-hLW
-hLW
+yhZ
+yhZ
+yhZ
+yhZ
+yhZ
 wtF
 fZJ
 fZJ
@@ -387440,7 +387457,7 @@ aUc
 vIa
 vIa
 wtF
-sfJ
+hLW
 hLW
 wtF
 wtF
@@ -487538,12 +487555,12 @@ aUc
 aUc
 uFE
 uFE
-uFE
-uFE
-uFE
-uFE
-uFE
-uFE
+wtF
+wtF
+wtF
+wtF
+wtF
+wtF
 tPh
 tPh
 tPh
@@ -487940,12 +487957,12 @@ aUc
 aUc
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-uFE
+wtF
+tgZ
+los
+bFU
+rdP
+mxR
 tPh
 tPh
 nkW
@@ -488342,14 +488359,14 @@ aUc
 aUc
 vIa
 vIa
-vIa
-vIa
-vIa
-vIa
-vIa
-uFE
+wtF
+los
+bFU
+tgZ
+wtF
+wtF
 fMc
-hEc
+hGn
 hGn
 hGn
 hGn
@@ -488744,14 +488761,14 @@ aUc
 aUc
 vIa
 vIa
-vIa
-vIa
-vIa
-uFE
-uFE
-uFE
-sXz
-esF
+wtF
+bFU
+tgZ
+los
+wtF
+wtF
+uJF
+uJF
 xAt
 xAt
 xAt
@@ -489146,14 +489163,14 @@ aUc
 aUc
 vIa
 vIa
-uFE
-uJF
-uJF
-uJF
-sXz
-sXz
-sXz
-svx
+wtF
+tgZ
+los
+bFU
+wtF
+wtF
+hSp
+hSp
 hSp
 hSp
 hSp
@@ -489548,11 +489565,11 @@ aUc
 aUc
 vIa
 vIa
-uJF
-sXz
-sXz
-sXz
-sXz
+wtF
+los
+bFU
+tgZ
+wtF
 wtF
 yei
 uwS
@@ -489950,11 +489967,11 @@ aUc
 aUc
 vIa
 vIa
-uJF
-iVj
-sXz
-sXz
-uJF
+wtF
+bFU
+tgZ
+los
+wtF
 naI
 tVZ
 rdP
@@ -490352,11 +490369,11 @@ aUc
 aUc
 vIa
 vIa
-uJF
-uJF
-uJF
-uJF
-uJF
+wtF
+tgZ
+los
+bFU
+wtF
 naI
 nPt
 rdP
@@ -490754,11 +490771,11 @@ aUc
 aUc
 vIa
 vIa
-uJF
-uJF
-uJF
-uJF
-uJF
+wtF
+los
+bFU
+tgZ
+wtF
 naI
 fHm
 rdP
@@ -490767,7 +490784,7 @@ naI
 tkS
 tgZ
 vKN
-tgZ
+cCw
 naI
 tWQ
 tWQ
@@ -491156,11 +491173,11 @@ aUc
 aUc
 vIa
 vIa
-uJF
-uJF
-uJF
-uJF
-uJF
+wtF
+bFU
+tgZ
+los
+wtF
 naI
 naI
 naI
@@ -491558,11 +491575,11 @@ aUc
 aUc
 vIa
 vIa
-uJF
-uJF
-uJF
-uJF
-uJF
+wtF
+tgZ
+los
+bFU
+wtF
 naI
 fAH
 dxv
@@ -491961,8 +491978,8 @@ aUc
 vIa
 vIa
 wtF
-nBW
-nBW
+los
+bFU
 wtF
 wtF
 naI
@@ -504020,7 +504037,7 @@ aUc
 aUc
 vIa
 uFE
-hEc
+hGn
 hGn
 hGn
 hGn
@@ -504422,7 +504439,7 @@ aUc
 aUc
 vIa
 uFE
-esF
+xAt
 xAt
 xAt
 xAt
@@ -504824,7 +504841,7 @@ aUc
 aUc
 vIa
 uFE
-esF
+xAt
 xAt
 xAt
 xAt
@@ -505226,7 +505243,7 @@ aUc
 aUc
 vIa
 uFE
-esF
+xAt
 xAt
 xAt
 xAt
@@ -505628,7 +505645,7 @@ aUc
 aUc
 vIa
 uFE
-svx
+hSp
 hSp
 hSp
 hSp


### PR DESCRIPTION
Changes out the balance of the wall's defenses, and changes the secret passage to being a exit only area. However the former secret area, was changed to being a newer entrance into the keep. A more natural, and moving slowly towards the medieval design of a manor. Mean while, this forces intruders that plans to breaking in. Has to account for the risk of falling off the wall, due to the gaps between the two structures.

**Why is the change good for this to happen?**

This is to balance out the size of the manor to being easier to defend. As the state was normally taken by the guard of men-at-arms. However as the roster went down to a less formable number of two manor guards, knights, squires, servants, and the nobility.  

Additional note: The Marshal who was present, was merged to being the captain fully, and this in turn. Left the room abandoned. So the councilors will be put into separate identical rooms. This allows them a assortment of privacy, let alone. Any request they make for anyone carpenters, builders, or whomever to comes in. This grants them freedom to have additions, and changes to their rooms.

Added a roof top, to cover the newly built bath's balcony. That way anyone who intrudes, has to go through particular areas of the manor. 
![Bath's balcony](https://github.com/user-attachments/assets/854361e3-aa95-4224-8856-f2961ecfd55a)
![East side of the manor](https://github.com/user-attachments/assets/812af4e9-0641-40a6-860e-73028643f056)
![image_2025-04-02_115039080](https://github.com/user-attachments/assets/b4d5f87f-92fd-4e14-946e-2aaf2a6d861f)

