### PR TITLE
Unironic Bandit Buff (not really)

### DIFF
--- a/code/modules/antagonists/roguetown/villain/bandit.dm
+++ b/code/modules/antagonists/roguetown/villain/bandit.dm
@@ -11,7 +11,7 @@
 		"I WILL NOT LIVE IN YOUR WALLS!",
 		"I WILL NOT FOLLOW YOUR RULES!",
 	)
-	var/favor = 50
+	var/favor = 250 //with removal of iron and steel bar turn ins, gives bandits a chance to get basic early supplies
 	var/totaldonated = 0
 
 /datum/antagonist/bandit/examine_friendorfoe(datum/antagonist/examined_datum,mob/examiner,mob/examined)

--- a/code/modules/jobs/job_types/roguetown/bandits/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/bandits/bandit.dm
@@ -3,8 +3,8 @@
 	flag = BANDIT
 	department_flag = FOREIGNERS
 	faction = "Station"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 6
+	spawn_positions = 6
 	antag_job = TRUE
 	allowed_races = RACES_VERY_SHUNNED_UP	//Begone foul seelies. Your age of banditry is gone
 	tutorial = "Long ago you did a crime worthy of your bounty being hung on the wall outside of the local inn. You now live with your fellow freemen in the bog, and generally get up to no good."

--- a/code/modules/jobs/job_types/roguetown/bandits/types/brigand.dm
+++ b/code/modules/jobs/job_types/roguetown/bandits/types/brigand.dm
@@ -40,12 +40,13 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
 	H.change_stat("strength", 3)
 	H.change_stat("endurance", 1)
-	H.change_stat("constitution", 2)
-	H.change_stat("perception", 1)
+	H.change_stat("constitution", 3)
+	H.change_stat("perception", 0)
 	H.change_stat("intelligence", -2)
 	H.change_stat("speed", 1)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_DEATHBYSNUSNU, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_ANTISCRYING, TRAIT_GENERIC)
 	H.adjust_blindness(-3)
 	var/weapons = list("Axe & Cudgel","Flail & Shield")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons

--- a/code/modules/jobs/job_types/roguetown/bandits/types/foresworn.dm
+++ b/code/modules/jobs/job_types/roguetown/bandits/types/foresworn.dm
@@ -44,6 +44,7 @@
 	H.change_stat("speed", 2)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_DEATHBYSNUSNU, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_ANTISCRYING, TRAIT_GENERIC)
 	H.adjust_blindness(-3)
 	var/weapons = list("Spear","Sword & Shield")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons

--- a/code/modules/jobs/job_types/roguetown/bandits/types/hedgeknight.dm
+++ b/code/modules/jobs/job_types/roguetown/bandits/types/hedgeknight.dm
@@ -53,6 +53,7 @@
 	ADD_TRAIT(H, TRAIT_DEATHBYSNUSNU, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC) //hey buddy you hear about roleplaying
 	ADD_TRAIT(H, TRAIT_WANTED, TRAIT_GENERIC) //Hedgeknights are known around the area
+	ADD_TRAIT(H, TRAIT_ANTISCRYING, TRAIT_GENERIC)
 	H.ambushable = FALSE
 
 /obj/effect/proc_holder/spell/invoked/joincomrades

--- a/code/modules/jobs/job_types/roguetown/bandits/types/knave.dm
+++ b/code/modules/jobs/job_types/roguetown/bandits/types/knave.dm
@@ -42,6 +42,7 @@
 	H.change_stat("speed", 3) //It's all about speed and perception
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC) //gets dodge expert but no medium armor training - gotta stay light
 	ADD_TRAIT(H, TRAIT_DEATHBYSNUSNU, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_ANTISCRYING, TRAIT_GENERIC)
 	H.adjust_blindness(-3)
 	var/weapons = list("2x Dagger", "Bow & Sword")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons

--- a/code/modules/jobs/job_types/roguetown/bandits/types/roguemage.dm
+++ b/code/modules/jobs/job_types/roguetown/bandits/types/roguemage.dm
@@ -52,6 +52,7 @@
 		H.change_stat("endurance", 1)
 		H.change_stat("speed",1)
 		ADD_TRAIT(H, TRAIT_DEATHBYSNUSNU, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_ANTISCRYING, TRAIT_GENERIC)
 		H.mind.adjust_spellpoints(4)
 		H.mind.AddSpell(new SPELL_PRESTIDIGITATION)
 		H.mind.AddSpell(new SPELL_LEARNSPELL)

--- a/code/modules/jobs/job_types/roguetown/bandits/types/sawbones.dm
+++ b/code/modules/jobs/job_types/roguetown/bandits/types/sawbones.dm
@@ -37,6 +37,7 @@
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC) //Given for consistencysake as the idol still provides scalemail.
 	ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC) // Vital for any surgical role dealing in potentially decaying bodies.
 	ADD_TRAIT(H, TRAIT_DEATHBYSNUSNU, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_ANTISCRYING, TRAIT_GENERIC)
 	H.change_stat("strength", 2)
 	H.change_stat("intelligence", 3)
 	H.change_stat("speed", 2)

--- a/code/modules/roguetown/roguejobs/miner/rogueores.dm
+++ b/code/modules/roguetown/roguejobs/miner/rogueores.dm
@@ -128,7 +128,7 @@
 	icon_state = "ingotiron"
 	smeltresult = /obj/item/ingot/iron
 	grind_results = list(/datum/reagent/iron = 15)
-	sellprice = 20
+	sellprice = 1
 
 /obj/item/ingot/copper
 	name = "copper bar"
@@ -136,21 +136,21 @@
 	icon_state = "ingotcop"
 	smeltresult = /obj/item/ingot/copper
 	grind_results = list(/datum/reagent/copper = 15)
-	sellprice = 20
+	sellprice = 1
 
 /obj/item/ingot/tin
 	name = "tin bar"
 	desc = "An ingot of strangely soft and malleable essence."
 	icon_state = "ingottin"
 	smeltresult = /obj/item/ingot/tin
-	sellprice = 20
+	sellprice = 1
 
 /obj/item/ingot/bronze
 	name = "bronze bar"
 	desc = "A hard and durable alloy favored by engineers and followers of Malum alike."
 	icon_state = "ingotbronze"
 	smeltresult = /obj/item/ingot/bronze
-	sellprice = 30
+	sellprice = 1
 
 /obj/item/ingot/silver
 	name = "silver bar"
@@ -165,7 +165,7 @@
 	desc = "This ingot is a stalwart defender of the kingdom."
 	icon_state = "ingotsteel"
 	smeltresult = /obj/item/ingot/steel
-	sellprice = 30
+	sellprice = 1
 
 /obj/item/ingot/blacksteel
 	name = "blacksteel bar"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Changes to bandit progression and SLIGHT stat tweak for Brigand seeing as they're supposed to be beefy but weren't.

Also adds antiscry to bandits as an extra metaprotection layer.

Aaaaaand changes default slots from 4 to 6.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I get off to balance changes, also this completely nerfs metal ingot trades so bandits can't cheese off of them. Silver, gold and blacksteel still have value.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->


## Proof of Testing (Required)

<!-- Show proof of testing, screenshots or recordings for features, proof of compile for backend changes -->
