### PR TITLE
Mace Meta Cucked

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -14,7 +14,7 @@
 	//dropshrink = 0.75
 	wlength = WLENGTH_NORMAL
 	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BACK
+	slot_flags = ITEM_SLOT_BACK
 	associated_skill = /datum/skill/combat/maces
 	anvilrepair = /datum/skill/craft/blacksmithing
 	smeltresult = /obj/item/ingot/iron
@@ -23,7 +23,7 @@
 	swingsound = BLUNTWOOSH_MED
 	minstr = 7
 	wdefense = 2
-	wbalance = -1
+	wbalance = -2
 	blade_dulling = DULLING_BASHCHOP
 
 /obj/item/rogueweapon/mace/attack_right(mob/user)
@@ -58,18 +58,18 @@
 	wbalance = -1
 	smeltresult = /obj/item/ingot/steel
 	blade_dulling = DULLING_BASH
-	wdefense = 3
+	wdefense = 2
 
 /obj/item/rogueweapon/mace/steel
-	force = 30
-	force_wielded = 40
+	force = 25
+	force_wielded = 35
 	name = "steel mace"
 	desc = "This steel mace is objectively superior to an iron one."
 	icon_state = "smace"
 	wbalance = -1
 	smeltresult = /obj/item/ingot/steel
 	blade_dulling = DULLING_BASH
-	wdefense = 3
+	wdefense = 2
 
 /obj/item/rogueweapon/mace/steel/attack_right(mob/user)
 	if(!overlays.len)
@@ -155,7 +155,7 @@
 	wbalance = -1
 	smeltresult = /obj/item/ingot/iron
 	blade_dulling = DULLING_BASH
-	wdefense = 3
+	wdefense = 1
 
 /obj/item/rogueweapon/mace/warhammer/steel
 	force = 25
@@ -164,7 +164,7 @@
 	desc = "A fine steel warhammer, makes a satisfying sound when paired with a knight's helm."
 	icon_state = "swarhammer"
 	smeltresult = /obj/item/ingot/steel
-	wdefense = 4
+	wdefense = 1
 
 /obj/item/rogueweapon/mace/warhammer/getonmobprop(tag)
 	if(tag)
@@ -193,9 +193,9 @@
 	blade_class = BCLASS_SMASH
 	attack_verb = list("smashes")
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
-	penfactor = 80
-	damfactor = 1.1
-	swingdelay = 10
+	penfactor = 30
+	damfactor = 0.9
+	swingdelay = 17.5
 	icon_state = "insmash"
 	item_d_type = "blunt"
 	
@@ -231,12 +231,12 @@
 	blade_class = BCLASS_PICK
 	attack_verb = list("picks", "impales")
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
-	chargetime = 14
+	chargetime = 25
 	chargedrain = 1
 	misscost = 1
 	no_early_release = TRUE
-	penfactor = 80
-	damfactor = 0.9
+	penfactor = 60
+	damfactor = 0.8
 	item_d_type = "stab"
 
 /obj/item/rogueweapon/mace/woodclub

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -233,7 +233,7 @@
 	smeltresult = /obj/item/ingot/steel
 	max_blade_int = 200
 	minstr = 8
-	wdefense = 6
+	wdefense = 5
 	throwforce = 15
 
 /obj/item/rogueweapon/spear/improvisedbillhook
@@ -294,7 +294,7 @@
 	associated_skill = /datum/skill/combat/polearms
 	blade_dulling = DULLING_BASHCHOP
 	walking_stick = TRUE
-	wdefense = 6
+	wdefense = 5
 
 /obj/item/rogueweapon/halberd/attack_right(mob/user)
 	if(!overlays.len)
@@ -367,7 +367,7 @@
 	associated_skill = /datum/skill/combat/polearms
 	blade_dulling = DULLING_BASHCHOP
 	walking_stick = TRUE
-	wdefense = 6
+	wdefense = 4
 
 /obj/item/rogueweapon/eaglebeak/getonmobprop(tag)
 	. = ..()
@@ -395,7 +395,7 @@
 
 /datum/intent/mace/smash/eaglebeak
 	reach = 2
-	swingdelay = 12
+	swingdelay = 17.5
 	clickcd = 14
 
 /obj/item/rogueweapon/spear/bronze


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Maces now only fit on a back slot and have increased delay before hitting, seeing as they've been the single most powerful class of weapon for a while. Lucerne/Eagle's beak have had their delay increased as well

## Why It's Good For The Game

Everyone running around with only maces was stupid, okay?


## Proof of Testing (Required)

<!-- Show proof of testing, screenshots or recordings for features, proof of compile for backend changes -->
