### PR TITLE
Fixes WARHAMMERS being able to completely dominate the battlefield. While aesthetically still cool, they were BUSTED.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -147,8 +147,8 @@
 
 /obj/item/rogueweapon/mace/warhammer
 	force = 20
-	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash, /datum/intent/mace/warhammer/impale)
-	gripped_intents = null
+	possible_item_intents = list(/datum/intent/mace/strike)
+	gripped_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash, /datum/intent/mace/warhammer/impale)
 	name = "warhammer"
 	desc = "Made to punch through armor and skull alike."
 	icon_state = "iwarhammer"
@@ -159,7 +159,8 @@
 
 /obj/item/rogueweapon/mace/warhammer/steel
 	force = 25
-	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash, /datum/intent/mace/warhammer/impale, /datum/intent/mace/warhammer/stab)
+	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/warhammer/stab)
+	gripped_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash, /datum/intent/mace/warhammer/impale, /datum/intent/mace/warhammer/stab)
 	name = "steel warhammer"
 	desc = "A fine steel warhammer, makes a satisfying sound when paired with a knight's helm."
 	icon_state = "swarhammer"

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -270,7 +270,7 @@
 /obj/item/rogueweapon/mace/cudgel
 	name = "cudgel"
 	desc = "A stubby little club for brigands."
-	force = 25
+	force = 20
 	icon_state = "cudgel"
 	force_wielded = 25
 	gripped_intents = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

I looked back through my mace rebalance only to find out that I missed out on WARHAMMERS, which had the ability to be used ungripped to perform smash and impale unlike every other weapon in the blunt list. Also slight cudgel damage tweak.

## Why It's Good For The Game

No more will there be one weapon to rule them all, hail balance.
