### PR TITLE
HOARDMASTAH / Hoardmaster Tweaks

### DIFF
--- a/code/modules/cargo/packsrogue/bandit/b_apparel.dm
+++ b/code/modules/cargo/packsrogue/bandit/b_apparel.dm
@@ -159,16 +159,6 @@
 	cost = 20
 	contains = list(/obj/item/clothing/neck/roguetown/collar/leather)
 
-/datum/supply_pack/rogue/bandit/Apparel/collarcat
-	name = "Leather Cat Collar"
-	cost = 40
-	contains = list(/obj/item/clothing/neck/roguetown/collar/leather/bell)
-
-/datum/supply_pack/rogue/bandit/Apparel/collarcow
-	name = "Leather Cow Collar"
-	cost = 40
-	contains = list(/obj/item/clothing/neck/roguetown/collar/leather/bell/cow)
-
 /datum/supply_pack/rogue/bandit/Apparel/Dragonscale
 	name = "Dragonscale Necklace"
 	cost = 2000

--- a/code/modules/cargo/packsrogue/bandit/clothing.dm
+++ b/code/modules/cargo/packsrogue/bandit/clothing.dm
@@ -114,20 +114,10 @@
 	cost = 40
 	contains = list(/obj/item/clothing/suit/roguetown/armor/leather/hide)
 
-/datum/supply_pack/rogue/bandit/Clothing/halfmasks
-	name = "Halfmask"
-	cost = 80
-	contains = list(/obj/item/clothing/mask/rogue/shepherd)
-
 /datum/supply_pack/rogue/bandit/Clothing/masks
 	name = "Steel Mask"
 	cost = 80
 	contains = list(/obj/item/clothing/mask/rogue/facemask/steel)
-
-/datum/supply_pack/rogue/bandit/Clothing/maskhound
-	name = "Hound Mask"
-	cost = 80
-	contains = list(/obj/item/clothing/mask/rogue/facemask/steel/hound)
 
 /datum/supply_pack/rogue/bandit/Clothing/maskgold
 	name = "Gold Mask"
@@ -139,16 +129,6 @@
 	cost = 40
 	contains = list(/obj/item/clothing/neck/roguetown/coif)
 
-/datum/supply_pack/rogue/bandit/Clothing/ropeleash
-	name = "Rope Leash"
-	cost = 5
-	contains = list(/obj/item/leash)
-
-/datum/supply_pack/rogue/bandit/Clothing/leatherleash
-	name = "Leather Leash"
-	cost = 20
-	contains = list(/obj/item/leash/leather)
-
 /datum/supply_pack/rogue/bandit/Clothing/chainleash
 	name = "Chain Leash"
 	cost = 50
@@ -158,16 +138,6 @@
 	name = "Leather Collar"
 	cost = 20
 	contains = list(/obj/item/clothing/neck/roguetown/collar/leather)
-
-/datum/supply_pack/rogue/bandit/Clothing/collarcat
-	name = "Leather Cat Collar"
-	cost = 40
-	contains = list(/obj/item/clothing/neck/roguetown/collar/leather/bell)
-
-/datum/supply_pack/rogue/bandit/Clothing/collarcow
-	name = "Leather Cow Collar"
-	cost = 40
-	contains = list(/obj/item/clothing/neck/roguetown/collar/leather/bell/cow)
 
 /datum/supply_pack/rogue/bandit/Clothing/Dragonscale
 	name = "Dragonscale Necklace"

--- a/code/modules/cargo/packsrogue/bandit/consumables.dm
+++ b/code/modules/cargo/packsrogue/bandit/consumables.dm
@@ -58,3 +58,14 @@
 	name = "Wine"
 	cost = 100
 	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/wine)
+
+
+/datum/supply_pack/rogue/bandit/Knave/Mancatcher
+	name = "Mancatcher"
+	cost = 50
+	contains = list(/obj/item/restraints/legcuffs/beartrap)
+
+/datum/supply_pack/rogue/bandit/Knave/smokebomb
+	name = "Smoke bomb"
+	cost = 25
+	contains = list(/obj/item/smokebomb)

--- a/code/modules/cargo/packsrogue/bandit/foresworn.dm
+++ b/code/modules/cargo/packsrogue/bandit/foresworn.dm
@@ -24,7 +24,7 @@
 	cost = 24
 	contains = list(/obj/item/clothing/head/roguetown/roguehood/shalal)
 
-//Armour
+//Armor
 /datum/supply_pack/rogue/bandit/Mage/gambeson
 	name = "Gambeson"
 	cost = 50

--- a/code/modules/cargo/packsrogue/bandit/knave.dm
+++ b/code/modules/cargo/packsrogue/bandit/knave.dm
@@ -61,11 +61,6 @@
 	contains = list(/obj/item/ammo_holder/quiver/bolts)
 
 //Misc
-/datum/supply_pack/rogue/bandit/Knave/Mancatcher
-	name = "Mancatcher"
-	cost = 50
-	contains = list(/obj/item/restraints/legcuffs/beartrap)
-
 /datum/supply_pack/rogue/bandit/Knave/lockpick
 	name = "lockpick"
 	cost = 40
@@ -75,11 +70,6 @@
 	name = "Empty lockpicking ring"
 	cost = 40
 	contains = list(/obj/item/lockpickring)
-
-/datum/supply_pack/rogue/bandit/Knave/smokebomb
-	name = "Smoke bomb"
-	cost = 25
-	contains = list(/obj/item/smokebomb)
 /datum/supply_pack/rogue/bandit/Knave/bombpouch
 	name = "Empty bomb pouch"
 	cost = 40


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes a LOT of fetish items from the hoardmaster, praise Matthios. Also moves beartraps and smokebombs to consumables so every class can buy them.

## Why It's Good For The Game

We don't need 3-4 collar and leash types in the fucking hoardmaster. What the fuck.


## Proof of Testing (Required)

![image](https://github.com/user-attachments/assets/f501bbc5-e7db-477e-ac4e-f06b9151ba3c)
