### PR TITLE
Hand and Consort balance (mostly)

### DIFF
--- a/code/datums/migrants/migrant_waves/heartfelt roles.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt roles.dm
@@ -44,12 +44,11 @@
 		H.change_stat("endurance", 2)
 		H.change_stat("speed", 1)
 		H.change_stat("perception", 2)
-		H.change_stat("fortune", 5)
+		H.change_stat("fortune", 2)
 
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOSEGRAB, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
 /datum/migrant_role/heartfelt/lady
 	name = "Lady of Heartfelt"
@@ -88,7 +87,7 @@
 		H.change_stat("endurance", 3)
 		H.change_stat("speed", 2)
 		H.change_stat("perception", 2)
-		H.change_stat("fortune", 5)
+		H.change_stat("fortune", 2)
 	ADD_TRAIT(H, TRAIT_SEEPRICES, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NUTCRACKER, TRAIT_GENERIC)
@@ -188,7 +187,6 @@
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOSEGRAB, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
 /datum/migrant_role/heartfelt/knight/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	..()

--- a/code/modules/jobs/job_types/roguetown/nobility/consort.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/consort.dm
@@ -89,7 +89,7 @@
 			H.change_stat("endurance", 3)
 			H.change_stat("speed", 2)
 			H.change_stat("perception", 2)
-			H.change_stat("fortune", 5)
+			H.change_stat("fortune", 2)
 
 		ADD_TRAIT(H, TRAIT_SEEPRICES, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
@@ -131,7 +131,7 @@
 			H.change_stat("endurance", 3)
 			H.change_stat("speed", 1)
 			H.change_stat("perception", 2)
-			H.change_stat("fortune", 5)
+			H.change_stat("fortune", 2)
 
 			H.dna.species.soundpack_m = new /datum/voicepack/male/evil()
 
@@ -146,7 +146,6 @@
 
 		ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_NOSEGRAB, TRAIT_GENERIC)
-		ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 
 /datum/outfit/job/roguetown/lady/post_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -72,16 +72,8 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 4, TRUE)
-		if(!isseelie(H))	//No stat changes for Seelie hands
-			H.change_stat("strength", 2)
-			H.change_stat("perception", 3)
-			H.change_stat("intelligence", 3)
-		else if(isseelie(H)) //Could just be an else, but prefer the extra layer
-			H.mind.AddSpell(new SPELL_PUSH_SPELL)			//Repulse, good for getting people away from the King
-			H.mind.AddSpell(new SPELL_ROUSTAME)			//Rous taming still makes sense for a Hand, a 'master of words' vibe. Summoning rats however does not - its undignified
-			H.mind.AddSpell(new SPELL_SLOWDOWN_SPELL_AOE)	//Immobilizes for 3 seconds in a 3x3, seems fitting for a Hand to be able to calm the court room when theres chaos
+		H.change_stat("strength", 2)
+		H.change_stat("perception", 3)
+		H.change_stat("intelligence", 3)
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
-	if(!isseelie(H))	//Only give heavy armor trait for non-seelie hands
-		ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	else if(isseelie(H))	//Since seelie hands no longer get heavy armor, giving them dodge expert instead
-		ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/nobility/ruler.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/ruler.dm
@@ -115,7 +115,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 			H.change_stat("endurance", 3)
 			H.change_stat("speed", 1)
 			H.change_stat("perception", 2)
-			H.change_stat("fortune", 5)
+			H.change_stat("fortune", 3)
 
 			H.dna.species.soundpack_m = new /datum/voicepack/male/evil()
 
@@ -159,7 +159,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 			H.change_stat("endurance", 3)
 			H.change_stat("speed", 2)
 			H.change_stat("perception", 2)
-			H.change_stat("fortune", 5)
+			H.change_stat("fortune", 3)
 
 		ADD_TRAIT(H, TRAIT_SEEPRICES, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes heavy armor training from hand and consort, also gimps super high fortune that they had, for some reason.

## Why It's Good For The Game

The hand and consort shouldn't have it, simple as. Also having like 5 fortune lets you crit spam anything you fight.


## Proof of Testing (Required)

![image](https://github.com/user-attachments/assets/b342f745-4a77-4e5d-9249-938d2ba346ec)
